### PR TITLE
Fixed missing reference to pthread_t on ubuntu

### DIFF
--- a/src/dynamic/pool.h
+++ b/src/dynamic/pool.h
@@ -1,5 +1,6 @@
 #ifndef POOL_H_INCLUDED
 #define POOL_H_INCLUDED
+#include <pthread.h>
 
 #define POOL_WORKERS_MIN 1
 #define POOL_WORKERS_MAX 16


### PR DESCRIPTION
Fixes compilation error